### PR TITLE
refactor: numeric constant parser structures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: test
+test:
+	cargo test --lib

--- a/src/constant_parser.rs
+++ b/src/constant_parser.rs
@@ -1,26 +1,33 @@
 use std::iter::Peekable;
 
-pub(crate) fn parse_numeric_constant(token_lexeme: &str) -> NumericConstant {
+pub(crate) fn parse_numeric_constant(token_lexeme: &str) -> ParseResult {
     let attrs = parse_num_const_attributes(token_lexeme);
     let (value, has_overflowed) = eval_integer_constant(attrs);
 
-    NumericConstant {
-        value: NumConstVal::Int(value),
+    ParseResult {
+        num_const: NumConst::Int(value),
         has_overflowed,
     }
 }
 
 #[derive(PartialEq, Eq, Debug)]
-pub(crate) struct NumericConstant {
-    pub(crate) value: NumConstVal,
+pub(crate) struct ParseResult {
+    pub(crate) num_const: NumConst,
     pub(crate) has_overflowed: bool,
 }
 
 #[derive(PartialEq, Eq, Debug)]
-pub(crate) enum NumConstVal {
-    // TODO: Labels for suffixes.
-    Int(u64),
+pub(crate) enum NumConst {
+    Int(IntConst),
 }
+
+
+#[derive(PartialEq, Eq, Debug)]
+pub(crate) enum IntConst {
+    // TODO: Labels for suffixes.
+    value: u64,
+}
+
 
 fn parse_num_const_attributes(token_lexeme: &str) -> NumConstAttrs {
     let mut seq = Seq::new(token_lexeme);

--- a/src/tests/constant_parser_tests.rs
+++ b/src/tests/constant_parser_tests.rs
@@ -2,15 +2,20 @@
 
 use proptest::prelude::*;
 
-use crate::constant_parser::{parse_numeric_constant, NumConstVal, NumericConstant};
+use crate::constant_parser::{parse_numeric_constant, IntegerConst, NumConst, ParseResult};
 
 #[test]
 fn single_digits_should_parse_into_integer_constant() {
     let inputs = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
     for input in inputs {
-        let expected = NumericConstant {
-            value: NumConstVal::Int(input.parse().unwrap()),
+        let integer = IntegerConst {
+            value: input.parse().unwrap(),
+            is_unsigned: false,
+        };
+
+        let expected = ParseResult {
+            num_const: NumConst::Int(integer),
             has_overflowed: false,
         };
 
@@ -26,8 +31,13 @@ proptest! {
         // Using at most 19 digits for this test, as that is the maximum number of digits that
         // guarantees it will never overflow 64 bits.
 
-        let expected = NumericConstant {
-            value: NumConstVal::Int(input.parse().unwrap()),
+        let integer = IntegerConst {
+            value: input.parse().unwrap(),
+            is_unsigned: false,
+        };
+
+        let expected = ParseResult {
+            num_const: NumConst::Int(integer),
             has_overflowed: false,
         };
 
@@ -40,8 +50,15 @@ proptest! {
     fn decimal_intenger_constants_that_go_over_64_bits_should_be_flagged_as_overflowed(
         input in "[1-9][0-9]{20,37}"
     ) {
-        let expected = NumericConstant {
-            value: NumConstVal::Int(input.parse::<u128>().unwrap() as u64),
+        let truncated_value = input.parse::<u128>().unwrap() as u64;
+
+        let integer = IntegerConst {
+            value: truncated_value,
+            is_unsigned: false,
+        };
+
+        let expected = ParseResult {
+            num_const: NumConst::Int(integer),
             has_overflowed: true,
         };
 
@@ -55,8 +72,11 @@ fn decimal_intenger_constant_that_goes_a_bit_over_64_bits_should_be_flagged_as_o
 
     assert_eq!(
         parse_numeric_constant(valid_input),
-        NumericConstant {
-            value: NumConstVal::Int(u64::MAX),
+        ParseResult {
+            num_const: NumConst::Int(IntegerConst {
+                value: u64::MAX,
+                is_unsigned: false
+            }),
             has_overflowed: false,
         }
     );
@@ -65,8 +85,11 @@ fn decimal_intenger_constant_that_goes_a_bit_over_64_bits_should_be_flagged_as_o
 
     assert_eq!(
         parse_numeric_constant(invalid_input),
-        NumericConstant {
-            value: NumConstVal::Int(0),
+        ParseResult {
+            num_const: NumConst::Int(IntegerConst {
+                value: 0,
+                is_unsigned: false
+            }),
             has_overflowed: true,
         }
     );
@@ -82,8 +105,13 @@ proptest! {
 
         let raw_value = u64::from_str_radix(&input[1..], 8).unwrap();
 
-        let expected = NumericConstant {
-            value: NumConstVal::Int(raw_value),
+        let integer = IntegerConst {
+            value: raw_value,
+            is_unsigned: false,
+        };
+
+        let expected = ParseResult {
+            num_const: NumConst::Int(integer),
             has_overflowed: false,
         };
 
@@ -96,10 +124,16 @@ proptest! {
     fn octal_intenger_constants_that_go_over_64_bits_should_be_flagged_as_overflowed(
         input in "0[1-7]{23,42}"
     ) {
-        let raw_value = u128::from_str_radix(&input[1..], 8).unwrap();
+        let truncated_value = u128::from_str_radix(&input[1..], 8).unwrap() as u64;
 
-        let expected = NumericConstant {
-            value: NumConstVal::Int(raw_value as u64),
+        let integer = IntegerConst {
+            value: truncated_value,
+            is_unsigned: false,
+        };
+
+
+        let expected = ParseResult {
+            num_const: NumConst::Int(integer),
             has_overflowed: true,
         };
 
@@ -113,8 +147,11 @@ fn octal_intenger_constant_that_goes_a_bit_over_64_bits_should_be_flagged_as_ove
 
     assert_eq!(
         parse_numeric_constant(valid_input),
-        NumericConstant {
-            value: NumConstVal::Int(u64::MAX),
+        ParseResult {
+            num_const: NumConst::Int(IntegerConst {
+                value: u64::MAX,
+                is_unsigned: false
+            }),
             has_overflowed: false,
         }
     );
@@ -123,8 +160,11 @@ fn octal_intenger_constant_that_goes_a_bit_over_64_bits_should_be_flagged_as_ove
 
     assert_eq!(
         parse_numeric_constant(invalid_input),
-        NumericConstant {
-            value: NumConstVal::Int(0),
+        ParseResult {
+            num_const: NumConst::Int(IntegerConst {
+                value: 0,
+                is_unsigned: false
+            }),
             has_overflowed: true,
         }
     );
@@ -140,8 +180,13 @@ proptest! {
 
         let raw_value = u64::from_str_radix(&input[2..], 16).unwrap();
 
-        let expected = NumericConstant {
-            value: NumConstVal::Int(raw_value),
+        let integer = IntegerConst {
+            value: raw_value,
+            is_unsigned: false,
+        };
+
+        let expected = ParseResult {
+            num_const: NumConst::Int(integer),
             has_overflowed: false,
         };
 
@@ -154,10 +199,15 @@ proptest! {
     fn hexadecimal_intenger_constants_that_go_over_64_bits_should_be_flagged_as_overflowed(
         input in "0[xX][1-9a-fA-F]{17,32}"
     ) {
-        let raw_value = u128::from_str_radix(&input[2..], 16).unwrap();
+        let truncated_value = u128::from_str_radix(&input[2..], 16).unwrap() as u64;
 
-        let expected = NumericConstant {
-            value: NumConstVal::Int(raw_value as u64),
+        let integer = IntegerConst {
+            value: truncated_value,
+            is_unsigned: false,
+        };
+
+        let expected = ParseResult {
+            num_const: NumConst::Int(integer),
             has_overflowed: true,
         };
 
@@ -171,8 +221,11 @@ fn hexadecimal_intenger_constant_that_goes_a_bit_over_64_bits_should_be_flagged_
 
     assert_eq!(
         parse_numeric_constant(valid_input),
-        NumericConstant {
-            value: NumConstVal::Int(u64::MAX),
+        ParseResult {
+            num_const: NumConst::Int(IntegerConst {
+                value: u64::MAX,
+                is_unsigned: false
+            }),
             has_overflowed: false,
         }
     );
@@ -181,8 +234,11 @@ fn hexadecimal_intenger_constant_that_goes_a_bit_over_64_bits_should_be_flagged_
 
     assert_eq!(
         parse_numeric_constant(invalid_input),
-        NumericConstant {
-            value: NumConstVal::Int(0),
+        ParseResult {
+            num_const: NumConst::Int(IntegerConst {
+                value: 0,
+                is_unsigned: false
+            }),
             has_overflowed: true,
         }
     );


### PR DESCRIPTION
This patch should allow for distinct attributes for both integer and floating point constants. It also allows the parser to get the inner structure from the parse result, so that there can be two different functions that further analyze semantics of the numeric constant.